### PR TITLE
Missing hashCode methods

### DIFF
--- a/core/src/main/java/com/threerings/config/dist/data/ConfigEntry.java
+++ b/core/src/main/java/com/threerings/config/dist/data/ConfigEntry.java
@@ -114,7 +114,8 @@ public class ConfigEntry extends SimpleStreamableObject
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = _key != null ? _key.hashCode() : 0;
         result = 31 * result + (_bytes != null ? Arrays.hashCode(_bytes) : 0);
         result = 31 * result + (_config != null ? _config.hashCode() : 0);

--- a/core/src/main/java/com/threerings/config/dist/data/ConfigEntry.java
+++ b/core/src/main/java/com/threerings/config/dist/data/ConfigEntry.java
@@ -113,6 +113,14 @@ public class ConfigEntry extends SimpleStreamableObject
             Arrays.equals(oentry._bytes, _bytes);
     }
 
+    @Override
+    public int hashCode() {
+        int result = _key != null ? _key.hashCode() : 0;
+        result = 31 * result + (_bytes != null ? Arrays.hashCode(_bytes) : 0);
+        result = 31 * result + (_config != null ? _config.hashCode() : 0);
+        return result;
+    }
+
     /** The config key. */
     protected ConfigKey _key;
 

--- a/core/src/main/java/com/threerings/config/dist/data/ConfigKey.java
+++ b/core/src/main/java/com/threerings/config/dist/data/ConfigKey.java
@@ -129,4 +129,11 @@ public class ConfigKey extends SimpleStreamableObject
 
     /** The config name. */
     protected String _name;
+
+    @Override
+    public int hashCode() {
+        int result = _cclass != null ? _cclass.hashCode() : 0;
+        result = 31 * result + (_name != null ? _name.hashCode() : 0);
+        return result;
+    }
 }

--- a/core/src/main/java/com/threerings/config/dist/data/ConfigKey.java
+++ b/core/src/main/java/com/threerings/config/dist/data/ConfigKey.java
@@ -131,7 +131,8 @@ public class ConfigKey extends SimpleStreamableObject
     protected String _name;
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = _cclass != null ? _cclass.hashCode() : 0;
         result = 31 * result + (_name != null ? _name.hashCode() : 0);
         return result;

--- a/core/src/main/java/com/threerings/config/swing/ConfigBox.java
+++ b/core/src/main/java/com/threerings/config/swing/ConfigBox.java
@@ -195,7 +195,8 @@ public class ConfigBox extends JComboBox
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return name != null ? name.hashCode() : 0;
         }
     }

--- a/core/src/main/java/com/threerings/config/swing/ConfigBox.java
+++ b/core/src/main/java/com/threerings/config/swing/ConfigBox.java
@@ -193,6 +193,11 @@ public class ConfigBox extends JComboBox
         {
             return Objects.equal(name, ((ConfigItem)other).name);
         }
+
+        @Override
+        public int hashCode() {
+            return name != null ? name.hashCode() : 0;
+        }
     }
 
     /** The message bundle to use for translation. */

--- a/core/src/main/java/com/threerings/editor/swing/editors/ColorizationEditor.java
+++ b/core/src/main/java/com/threerings/editor/swing/editors/ColorizationEditor.java
@@ -202,6 +202,11 @@ public class ColorizationEditor extends PropertyEditor
         {
             return record == ((ClassItem)other).record;
         }
+
+        @Override
+        public int hashCode() {
+            return record != null ? record.hashCode() : 0;
+        }
     }
 
     /**
@@ -234,6 +239,11 @@ public class ColorizationEditor extends PropertyEditor
         public boolean equals (Object other)
         {
             return record == ((ColorItem)other).record;
+        }
+
+        @Override
+        public int hashCode() {
+            return record != null ? record.hashCode() : 0;
         }
     }
 

--- a/core/src/main/java/com/threerings/editor/swing/editors/ColorizationEditor.java
+++ b/core/src/main/java/com/threerings/editor/swing/editors/ColorizationEditor.java
@@ -204,7 +204,8 @@ public class ColorizationEditor extends PropertyEditor
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return record != null ? record.hashCode() : 0;
         }
     }
@@ -242,7 +243,8 @@ public class ColorizationEditor extends PropertyEditor
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return record != null ? record.hashCode() : 0;
         }
     }

--- a/core/src/main/java/com/threerings/opengl/model/tools/ModelDef.java
+++ b/core/src/main/java/com/threerings/opengl/model/tools/ModelDef.java
@@ -985,6 +985,11 @@ public class ModelDef
         {
             return Arrays.equals(tcoords, ((Extra)other).tcoords);
         }
+
+        @Override
+        public int hashCode() {
+            return tcoords != null ? Arrays.hashCode(tcoords) : 0;
+        }
     }
 
     /**
@@ -1100,6 +1105,10 @@ public class ModelDef
             return weight == ((BoneWeight)other).weight;
         }
 
+        @Override
+        public int hashCode() {
+            return (weight != +0.0f ? Float.floatToIntBits(weight) : 0);
+        }
         @Override
         public String toString ()
         {

--- a/core/src/main/java/com/threerings/opengl/model/tools/ModelDef.java
+++ b/core/src/main/java/com/threerings/opengl/model/tools/ModelDef.java
@@ -987,7 +987,8 @@ public class ModelDef
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return tcoords != null ? Arrays.hashCode(tcoords) : 0;
         }
     }
@@ -1106,7 +1107,8 @@ public class ModelDef
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return (weight != +0.0f ? Float.floatToIntBits(weight) : 0);
         }
         @Override

--- a/core/src/main/java/com/threerings/opengl/renderer/ClientArray.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/ClientArray.java
@@ -169,4 +169,16 @@ public class ClientArray
             offset == oarray.offset && arrayBuffer == oarray.arrayBuffer &&
             floatArray == oarray.floatArray;
     }
+
+    @Override
+    public int hashCode() {
+        int result = size;
+        result = 31 * result + type;
+        result = 31 * result + (normalized ? 1 : 0);
+        result = 31 * result + stride;
+        result = 31 * result + (int) (offset ^ (offset >>> 32));
+        result = 31 * result + (arrayBuffer != null ? arrayBuffer.hashCode() : 0);
+        result = 31 * result + (floatArray != null ? floatArray.hashCode() : 0);
+        return result;
+    }
 }

--- a/core/src/main/java/com/threerings/opengl/renderer/ClientArray.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/ClientArray.java
@@ -171,7 +171,8 @@ public class ClientArray
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = size;
         result = 31 * result + type;
         result = 31 * result + (normalized ? 1 : 0);

--- a/core/src/main/java/com/threerings/opengl/renderer/Program.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/Program.java
@@ -134,7 +134,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return value;
         }
     }
@@ -187,7 +188,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return (value != +0.0f ? Float.floatToIntBits(value) : 0);
         }
     }
@@ -240,7 +242,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return value != null ? value.hashCode() : 0;
         }
     }
@@ -293,7 +296,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return value != null ? value.hashCode() : 0;
         }
     }
@@ -346,7 +350,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return value != null ? value.hashCode() : 0;
         }
     }
@@ -400,7 +405,8 @@ public class Program extends ShaderObject
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return value != null ? value.hashCode() : 0;
         }
     }

--- a/core/src/main/java/com/threerings/opengl/renderer/Program.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/Program.java
@@ -132,6 +132,11 @@ public class Program extends ShaderObject
             return other instanceof IntegerUniform &&
                 ((IntegerUniform)other).value == value;
         }
+
+        @Override
+        public int hashCode() {
+            return value;
+        }
     }
 
     /**
@@ -179,6 +184,11 @@ public class Program extends ShaderObject
         {
             return other instanceof FloatUniform &&
                 ((FloatUniform)other).value == value;
+        }
+
+        @Override
+        public int hashCode() {
+            return (value != +0.0f ? Float.floatToIntBits(value) : 0);
         }
     }
 
@@ -228,6 +238,11 @@ public class Program extends ShaderObject
             return other instanceof Vector2fUniform &&
                 ((Vector2fUniform)other).value.equals(value);
         }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
     }
 
     /**
@@ -275,6 +290,11 @@ public class Program extends ShaderObject
         {
             return other instanceof Vector3fUniform &&
                 ((Vector3fUniform)other).value.equals(value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
         }
     }
 
@@ -324,6 +344,11 @@ public class Program extends ShaderObject
             return other instanceof Vector4fUniform &&
                 ((Vector4fUniform)other).value.equals(value);
         }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
     }
 
     /**
@@ -372,6 +397,11 @@ public class Program extends ShaderObject
         {
             return other instanceof Matrix4fUniform &&
                 ((Matrix4fUniform)other).value.equals(value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
         }
     }
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/AlphaState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/AlphaState.java
@@ -176,7 +176,8 @@ public class AlphaState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = _alphaTestFunc;
         result = 31 * result + (_alphaTestRef != +0.0f ? Float.floatToIntBits(_alphaTestRef) : 0);
         result = 31 * result + _srcBlendFactor;

--- a/core/src/main/java/com/threerings/opengl/renderer/state/AlphaState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/AlphaState.java
@@ -175,6 +175,15 @@ public class AlphaState extends RenderState
             _destBlendFactor == ostate._destBlendFactor;
     }
 
+    @Override
+    public int hashCode() {
+        int result = _alphaTestFunc;
+        result = 31 * result + (_alphaTestRef != +0.0f ? Float.floatToIntBits(_alphaTestRef) : 0);
+        result = 31 * result + _srcBlendFactor;
+        result = 31 * result + _destBlendFactor;
+        return result;
+    }
+
     /** The alpha test function. */
     protected int _alphaTestFunc;
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/ColorState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/ColorState.java
@@ -96,7 +96,8 @@ public class ColorState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return _color != null ? _color.hashCode() : 0;
     }
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/ColorState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/ColorState.java
@@ -95,6 +95,11 @@ public class ColorState extends RenderState
         return other instanceof ColorState && _color.equals(((ColorState)other)._color);
     }
 
+    @Override
+    public int hashCode() {
+        return _color != null ? _color.hashCode() : 0;
+    }
+
     /** The draw color. */
     protected Color4f _color = new Color4f();
 }

--- a/core/src/main/java/com/threerings/opengl/renderer/state/CullState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/CullState.java
@@ -97,7 +97,8 @@ public class CullState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return _cullFace;
     }
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/CullState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/CullState.java
@@ -96,6 +96,11 @@ public class CullState extends RenderState
             _cullFace == ((CullState)other)._cullFace;
     }
 
+    @Override
+    public int hashCode() {
+        return _cullFace;
+    }
+
     /** The cull face (or -1 if disabled). */
     protected int _cullFace = -1;
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/LineState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/LineState.java
@@ -92,7 +92,8 @@ public class LineState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return (_lineWidth != +0.0f ? Float.floatToIntBits(_lineWidth) : 0);
     }
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/LineState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/LineState.java
@@ -91,6 +91,11 @@ public class LineState extends RenderState
         return other instanceof LineState && _lineWidth == ((LineState)other)._lineWidth;
     }
 
+    @Override
+    public int hashCode() {
+        return (_lineWidth != +0.0f ? Float.floatToIntBits(_lineWidth) : 0);
+    }
+
     /** The line width. */
     protected float _lineWidth;
 }

--- a/core/src/main/java/com/threerings/opengl/renderer/state/MaterialState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/MaterialState.java
@@ -346,6 +346,27 @@ public class MaterialState extends RenderState
             _separateSpecular == ostate._separateSpecular && _flatShading == ostate._flatShading;
     }
 
+    @Override
+    public int hashCode() {
+        int result = _frontAmbient != null ? _frontAmbient.hashCode() : 0;
+        result = 31 * result + (_frontDiffuse != null ? _frontDiffuse.hashCode() : 0);
+        result = 31 * result + (_frontSpecular != null ? _frontSpecular.hashCode() : 0);
+        result = 31 * result + (_frontEmission != null ? _frontEmission.hashCode() : 0);
+        result = 31 * result + (_frontShininess != +0.0f ? Float.floatToIntBits(_frontShininess) : 0);
+        result = 31 * result + (_backAmbient != null ? _backAmbient.hashCode() : 0);
+        result = 31 * result + (_backDiffuse != null ? _backDiffuse.hashCode() : 0);
+        result = 31 * result + (_backSpecular != null ? _backSpecular.hashCode() : 0);
+        result = 31 * result + (_backEmission != null ? _backEmission.hashCode() : 0);
+        result = 31 * result + (_backShininess != +0.0f ? Float.floatToIntBits(_backShininess) : 0);
+        result = 31 * result + _colorMaterialMode;
+        result = 31 * result + _colorMaterialFace;
+        result = 31 * result + (_twoSide ? 1 : 0);
+        result = 31 * result + (_localViewer ? 1 : 0);
+        result = 31 * result + (_separateSpecular ? 1 : 0);
+        result = 31 * result + (_flatShading ? 1 : 0);
+        return result;
+    }
+
     /** The front ambient color. */
     protected Color4f _frontAmbient = new Color4f();
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/MaterialState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/MaterialState.java
@@ -347,7 +347,8 @@ public class MaterialState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = _frontAmbient != null ? _frontAmbient.hashCode() : 0;
         result = 31 * result + (_frontDiffuse != null ? _frontDiffuse.hashCode() : 0);
         result = 31 * result + (_frontSpecular != null ? _frontSpecular.hashCode() : 0);

--- a/core/src/main/java/com/threerings/opengl/renderer/state/PointState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/PointState.java
@@ -91,6 +91,11 @@ public class PointState extends RenderState
         return other instanceof PointState && _pointSize == ((PointState)other)._pointSize;
     }
 
+    @Override
+    public int hashCode() {
+        return (_pointSize != +0.0f ? Float.floatToIntBits(_pointSize) : 0);
+    }
+
     /** The point size. */
     protected float _pointSize;
 }

--- a/core/src/main/java/com/threerings/opengl/renderer/state/PointState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/PointState.java
@@ -92,7 +92,8 @@ public class PointState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return (_pointSize != +0.0f ? Float.floatToIntBits(_pointSize) : 0);
     }
 

--- a/core/src/main/java/com/threerings/opengl/renderer/state/PolygonState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/PolygonState.java
@@ -139,7 +139,8 @@ public class PolygonState extends RenderState
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = _frontPolygonMode;
         result = 31 * result + _backPolygonMode;
         result = 31 * result + (_polygonOffsetFactor != +0.0f ? Float.floatToIntBits(_polygonOffsetFactor) : 0);

--- a/core/src/main/java/com/threerings/opengl/renderer/state/PolygonState.java
+++ b/core/src/main/java/com/threerings/opengl/renderer/state/PolygonState.java
@@ -138,6 +138,15 @@ public class PolygonState extends RenderState
             _polygonOffsetUnits == ostate._polygonOffsetUnits;
     }
 
+    @Override
+    public int hashCode() {
+        int result = _frontPolygonMode;
+        result = 31 * result + _backPolygonMode;
+        result = 31 * result + (_polygonOffsetFactor != +0.0f ? Float.floatToIntBits(_polygonOffsetFactor) : 0);
+        result = 31 * result + (_polygonOffsetUnits != +0.0f ? Float.floatToIntBits(_polygonOffsetUnits) : 0);
+        return result;
+    }
+
     /** The front polygon mode. */
     protected int _frontPolygonMode;
 


### PR DESCRIPTION
I used IntelliJ's helper to generate these. I hand-verified that the same fields are compared in `equals` and `hashcode`.