### PR TITLE
Adding a @SafeVarargs annotation to suppress a warning

### DIFF
--- a/core/src/main/java/com/threerings/tudey/client/sprite/ActorSprite.java
+++ b/core/src/main/java/com/threerings/tudey/client/sprite/ActorSprite.java
@@ -748,6 +748,7 @@ public class ActorSprite extends Sprite
             /**
              * Creates a new activity.
              */
+            @SafeVarargs
             public Activity (ConfigReference<AnimationConfig>... anims)
             {
                 List<Animation> list = Lists.newArrayListWithCapacity(anims.length);


### PR DESCRIPTION
I had not encoutned this problem before. Here is the relevant stackoverflow post:
http://stackoverflow.com/questions/12462079/potential-heap-pollution-via-varargs-parameter

Even though this is a tiny change, I'm creating a PR because I'm not very familiar withe this part of the code or the warning.

```
    [javac] clyde/core/src/main/java/com/threerings/tudey/client/sprite/ActorSprite.java:751: warning: [unchecked] Possible heap pollution from parameterized vararg type ConfigReference<AnimationConfig>
    [javac]             public Activity (ConfigReference<AnimationConfig>... anims)
    [javac]                                                                  ^
    [javac] 1 warning
```
